### PR TITLE
Improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ username=
 password=
 iModelID=
 iTwinID=
+baseUrl=

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 reports
 test-results
+test-run-report.json

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "artillery run scripts/the-pied-pine-perf.yml",
-    "parseReports": "node parseReports.js"
+    "test": "artillery run --output test-run-report.json scripts/the-pied-pine-perf.yml",
+    "parseReports": "node parseReports.js && artillery report test-run-report.json"
   },
   "keywords": [],
   "author": "",

--- a/scripts/the-pied-pine-perf.yml
+++ b/scripts/the-pied-pine-perf.yml
@@ -21,9 +21,7 @@ config:
     threshold: 100
   ensure:
       thresholds:
-        # I can't get these thresholds to work... they always fail no matter how high I set them
-        - http.response_time.p99: 100000
-        - http.response_time.p50: 100000
+        - browser.step.spinner_stage.median: 20000 # If actually implementing as part of a CI pipeline, then this asserts the spinner test did not go past 20 seconds.
 scenarios:
   - engine: playwright
     testFunction: untilCanvas

--- a/tests/auth.mjs
+++ b/tests/auth.mjs
@@ -6,16 +6,9 @@ const OIDC = {
   signInButton: "id=sign-in-button",
 };
 
-export const loginPopup = async (page, user, appUrl) => {
-  await page.goto(appUrl, { timeout: 120000 });
-  const [popup] = await Promise.all([
-    page.waitForEvent("popup", { timeout: 60000 }),
-  ]);
-  await popup.waitForLoadState();
-
+export const loginPopup = async (page, popup, user, appUrl) => {
   await fillAuth(popup, user);
-  await popup.reload(); // for the test user, the popup fails to load the auth redirect for some reason, but the login succeeds. A reload cures all.
-  await page.waitForURL(appUrl);
+  return popup;
 };
 
 export const loginRedirect = async (page, user, appUrl) => {

--- a/tests/test.mjs
+++ b/tests/test.mjs
@@ -9,6 +9,7 @@ dotenv.config();
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+const baseUrl = process.env.baseUrl
 const username = process.env.username;
 const password = process.env.password;
 const iTwinId = process.env.iTwinID;
@@ -24,8 +25,7 @@ const testUser = {
   username,
   password,
 };
-
-const appURL = `/context/${iTwinId}/imodel/${iModelId}?testMode&logToConsole`;
+const appURL = `${baseUrl}/context/${iTwinId}/imodel/${iModelId}?testMode&logToConsole`;
 
 export async function untilCanvas(page, vuContext, events, test) {
   const { step } = test;
@@ -48,7 +48,7 @@ export async function untilCanvas(page, vuContext, events, test) {
   });
 
   let fullReport;
-  await step("spinner stage", async () => {
+  await step("spinner_stage", async () => {
     const lazyFullReport = getFullReport(page);
     await page.waitForSelector("canvas");
     fullReport = await lazyFullReport;
@@ -61,6 +61,9 @@ export async function untilCanvas(page, vuContext, events, test) {
     path.resolve(reportFolderPath,`./fullReport-${Date.now()}.json`),
     JSON.stringify(fullReport, null, 2)
   );
+
+  // TODO: Implement imodel backend shutdown function here. Also, probably do this after all vu sessions, instead of per vu session? If per vu session, then gotta set a delay in artillery yaml.
+  // TODO: If doing after all vu sessions, we can user the afterResponse param in extension-apis, and call the shutdown function.
 }
 
 async function getFullReport(page) {

--- a/tests/test.mjs
+++ b/tests/test.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from "url";
 import { dirname } from "path";
 import { loginPopup } from "./auth.mjs";
 import * as dotenv from "dotenv";
+import { existsSync, mkdirSync } from "fs";
 dotenv.config();
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -26,13 +27,38 @@ const testUser = {
 
 const appURL = `/context/${iTwinId}/imodel/${iModelId}?testMode&logToConsole`;
 
-export async function untilCanvas(page) {
-  await loginPopup(page, testUser, appURL);
-  const lazyFullReport = getFullReport(page);
-  await page.waitForSelector("canvas");
-  const fullReport = await lazyFullReport;
+export async function untilCanvas(page, vuContext, events, test) {
+  const { step } = test;
+
+  let popup;
+  await step("pre_login_redirect", async () => { // We can use this to measure time to retrieve Pineapple's chunked bundle files.
+    await page.goto(appURL, { timeout: 120000 });
+    [ popup ] = await Promise.all([
+      page.waitForEvent("popup", { timeout: 60000 }),
+    ]);
+    await popup.waitForLoadState();
+  });
+
+  await step("login", async () => {
+    popup = await loginPopup(page, popup, testUser, appURL);
+  });
+  await step("post_login", async () => {
+    await popup.reload(); // for the test user, the popup fails to load the auth redirect for some reason, but the login succeeds. A reload cures all.
+    await page.waitForURL(appURL);
+  });
+
+  let fullReport;
+  await step("spinner stage", async () => {
+    const lazyFullReport = getFullReport(page);
+    await page.waitForSelector("canvas");
+    fullReport = await lazyFullReport;
+  });
+  const reportFolderPath = path.resolve(__dirname, "..", "reports");
+  if (!existsSync(reportFolderPath)) { // if folder doesn't exist, create.
+    mkdirSync(reportFolderPath);
+  }
   await fs.writeFile(
-    path.resolve(__dirname, "..", "reports", `./fullReport-${Date.now()}.json`),
+    path.resolve(reportFolderPath,`./fullReport-${Date.now()}.json`),
     JSON.stringify(fullReport, null, 2)
   );
 }


### PR DESCRIPTION
- Split the performance test's metrics into multiple steps. Each step will have its own metrics tracked: 
1. pre_login_redirect (to measure retrieving pineapple's bundled files)
2. login (to isolate oidc signin from pineapple)
3. post_login (to isolate the redirect from login)
4. spinner_stage (to measure the initialization after login. This is where we also track and save the FullModuleReport)

- Implemented baseUrl logic, updated .env
- Implemented a test assertion in artillery's config yaml file, based on the spinner stage.
- added a .html report that will be output. For a user friendly summary of the metrics.
- Auto creates the reports folder where the FullModuleReport from Pineapple (NOT the artillery metrics report) will be output.