### PR TITLE
Add request logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
-username=
-password=
+TEST_USERNAME=
+TEST_PASSWORD=
 iModelID=
 iTwinID=
 baseUrl=
+azBlobConnectionString=

--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@
 - `pnpm install`
 - `pnpm test`
 - `pnpm parseReports`
+
+Note: add an azure blob storage connection string to the `.env` (azBlobConnectionString) file to upload reports.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@azure/storage-blob": "^12.17.0",
     "artillery": "^2.0.7",
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "playwright": "^1.42.1",
+    "playwright-chromium": "^1.42.1"
   }
 }

--- a/parseReports.js
+++ b/parseReports.js
@@ -66,7 +66,7 @@ export async function getMostExpensiveRequests(numRequests = 10) {
     for (const url in jsonData) {
       const durations = jsonData[url];
       const sum = durations.reduce(
-        (acc, duration) => acc + duration.responseEnd - duration.requestStart,
+        (acc, duration) => acc + (duration.responseEnd - duration.requestStart),
         0
       );
       const average = sum / durations.length;

--- a/parseReports.js
+++ b/parseReports.js
@@ -6,7 +6,7 @@ import { dirname } from "path";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const directoryPath = path.join(__dirname, "reports");
 
-const calculateStatistics = (capabilityName, slowCapabilitiesDurations) => {
+function calculateStatistics(capabilityName, slowCapabilitiesDurations) {
   const sum = slowCapabilitiesDurations.reduce(
     (acc, duration) => acc + duration,
     0
@@ -21,7 +21,7 @@ const calculateStatistics = (capabilityName, slowCapabilitiesDurations) => {
   console.log("Minimum:", minimum);
   console.log("Maximum:", maximum);
   console.log("\n");
-};
+}
 
 const files = await fs.readdir(directoryPath);
 const capabilitiesData = {};
@@ -47,7 +47,37 @@ for (const file of files) {
   });
 }
 
-for (const capabilityName in capabilitiesData) {
-  const slowCapabilitiesDurations = capabilitiesData[capabilityName];
-  calculateStatistics(capabilityName, slowCapabilitiesDurations);
+export function caclulateStatsFromFullReport() {
+  for (const capabilityName in capabilitiesData) {
+    const slowCapabilitiesDurations = capabilitiesData[capabilityName];
+    calculateStatistics(capabilityName, slowCapabilitiesDurations);
+  }
 }
+
+export async function getMostExpensiveRequests(numRequests = 10) {
+  const files = await fs.readdir(directoryPath);
+  const requests = [];
+  for (const file of files) {
+    if (!file.startsWith("requests-") || !file.endsWith(".json")) continue;
+
+    const filePath = path.join(directoryPath, file);
+    const fileData = await fs.readFile(filePath, "utf8");
+    const jsonData = JSON.parse(fileData);
+    for (const url in jsonData) {
+      const durations = jsonData[url];
+      const sum = durations.reduce(
+        (acc, duration) => acc + duration.responseEnd - duration.requestStart,
+        0
+      );
+      const average = sum / durations.length;
+      requests.push({ url, average });
+    }
+
+    // sort the requests by duration and take the first 10
+    requests.sort((a, b) => b.average - a.average);
+    console.log(requests.slice(0, numRequests));
+  }
+}
+
+caclulateStatsFromFullReport();
+getMostExpensiveRequests();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,12 +5,21 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@azure/storage-blob':
+    specifier: ^12.17.0
+    version: 12.17.0
   artillery:
     specifier: ^2.0.7
     version: 2.0.7(@types/node@20.11.24)(typescript@5.3.3)
   dotenv:
     specifier: ^16.4.5
     version: 16.4.5
+  playwright:
+    specifier: ^1.42.1
+    version: 1.42.1
+  playwright-chromium:
+    specifier: ^1.42.1
+    version: 1.42.1
 
 packages:
 
@@ -643,6 +652,107 @@ packages:
       tslib: 2.6.2
     dev: false
 
+  /@azure/abort-controller@1.1.0:
+    resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@azure/abort-controller@2.1.0:
+    resolution: {integrity: sha512-SYtcG13aiV7znycu6plCClWUzD9BBtfnsbIxT89nkkRvQRB4n0kuZyJJvJ7hqdKOn7x7YoGKZ9lVStLJpLnOFw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@azure/core-auth@1.7.0:
+    resolution: {integrity: sha512-OuDVn9z2LjyYbpu6e7crEwSipa62jX7/ObV/pmXQfnOG8cHwm363jYtg3FSX3GB1V7jsIKri1zgq7mfXkFk/qw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@azure/abort-controller': 2.1.0
+      '@azure/core-util': 1.8.0
+      tslib: 2.6.2
+    dev: false
+
+  /@azure/core-http@3.0.4:
+    resolution: {integrity: sha512-Fok9VVhMdxAFOtqiiAtg74fL0UJkt0z3D+ouUUxcRLzZNBioPRAMJFVxiWoJljYpXsRi4GDQHzQHDc9AiYaIUQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@azure/abort-controller': 1.1.0
+      '@azure/core-auth': 1.7.0
+      '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/core-util': 1.8.0
+      '@azure/logger': 1.1.0
+      '@types/node-fetch': 2.6.11
+      '@types/tunnel': 0.0.3
+      form-data: 4.0.0
+      node-fetch: 2.7.0
+      process: 0.11.10
+      tslib: 2.6.2
+      tunnel: 0.0.6
+      uuid: 8.3.2
+      xml2js: 0.5.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@azure/core-lro@2.7.0:
+    resolution: {integrity: sha512-oj7d8vWEvOREIByH1+BnoiFwszzdE7OXUEd6UTv+cmx5HvjBBlkVezm3uZgpXWaxDj5ATL/k89+UMeGx1Ou9TQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@azure/abort-controller': 2.1.0
+      '@azure/core-util': 1.8.0
+      '@azure/logger': 1.1.0
+      tslib: 2.6.2
+    dev: false
+
+  /@azure/core-paging@1.6.0:
+    resolution: {integrity: sha512-W8eRv7MVFx/jbbYfcRT5+pGnZ9St/P1UvOi+63vxPwuQ3y+xj+wqWTGxpkXUETv3szsqGu0msdxVtjszCeB4zA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@azure/core-tracing@1.0.0-preview.13:
+    resolution: {integrity: sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      tslib: 2.6.2
+    dev: false
+
+  /@azure/core-util@1.8.0:
+    resolution: {integrity: sha512-w8NrGnrlGDF7fj36PBnJhGXDK2Y3kpTOgL7Ksb5snEHXq/3EAbKYOp1yqme0yWCUlSDq5rjqvxSBAJmsqYac3w==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@azure/abort-controller': 2.1.0
+      tslib: 2.6.2
+    dev: false
+
+  /@azure/logger@1.1.0:
+    resolution: {integrity: sha512-BnfkfzVEsrgbVCtqq0RYRMePSH2lL/cgUUR5sYRF4yNN10zJZq/cODz0r89k3ykY83MqeM3twR292a3YBNgC3w==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@azure/storage-blob@12.17.0:
+    resolution: {integrity: sha512-sM4vpsCpcCApagRW5UIjQNlNylo02my2opgp0Emi8x888hZUvJ3dN69Oq20cEGXkMUWnoCrBaB0zyS3yeB87sQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@azure/abort-controller': 1.1.0
+      '@azure/core-http': 3.0.4
+      '@azure/core-lro': 2.7.0
+      '@azure/core-paging': 1.6.0
+      '@azure/core-tracing': 1.0.0-preview.13
+      '@azure/logger': 1.1.0
+      events: 3.3.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /@babel/helper-string-parser@7.23.4:
     resolution: {integrity: sha1-lHjHB/68u+Hds4o9kaLgVK5iLYM=}
     engines: {node: '>=6.9.0'}
@@ -671,7 +781,7 @@ packages:
     dev: false
 
   /@colors/colors@1.5.0:
-    resolution: {integrity: sha1-u1BFecHK6SPmV2pPXaQ9Jfl729k=}
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
     requiresBuild: true
     dev: false
@@ -1751,6 +1861,13 @@ packages:
       '@types/node': 20.11.24
     dev: false
 
+  /@types/node-fetch@2.6.11:
+    resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
+    dependencies:
+      '@types/node': 20.11.24
+      form-data: 4.0.0
+    dev: false
+
   /@types/node@20.11.24:
     resolution: {integrity: sha1-zCB1ERBGlOhOn7F/mgxMQtRRd5I=}
     dependencies:
@@ -1759,6 +1876,12 @@ packages:
 
   /@types/responselike@1.0.3:
     resolution: {integrity: sha1-zClwbwo5fP5t+J3r/kv1zqFZ21A=}
+    dependencies:
+      '@types/node': 20.11.24
+    dev: false
+
+  /@types/tunnel@0.0.3:
+    resolution: {integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==}
     dependencies:
       '@types/node': 20.11.24
     dev: false
@@ -2447,7 +2570,7 @@ packages:
     dev: false
 
   /cookie@0.4.1:
-    resolution: {integrity: sha1-r9cT/ibr0hupXOth+agRblClN9E=}
+    resolution: {integrity: sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -2867,6 +2990,11 @@ packages:
     engines: {node: '>=0.4.x'}
     dev: false
 
+  /events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+    dev: false
+
   /extend@3.0.2:
     resolution: {integrity: sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=}
     dev: false
@@ -3014,7 +3142,7 @@ packages:
     dev: false
 
   /fsevents@2.3.2:
-    resolution: {integrity: sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=}
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -3580,7 +3708,7 @@ packages:
     dev: false
 
   /long@5.2.3:
-    resolution: {integrity: sha1-o7qX84d88dd47MvLBIUl67d0meE=}
+    resolution: {integrity: sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==}
     dev: false
 
   /lowercase-keys@2.0.0:
@@ -3738,6 +3866,18 @@ packages:
     resolution: {integrity: sha1-hiO8UYuhYvj/HNuJQddN6w/cwBY=}
     dev: false
 
+  /node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
+
   /node-int64@0.4.0:
     resolution: {integrity: sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=}
     dev: false
@@ -3855,14 +3995,23 @@ packages:
     engines: {node: '>=8.6'}
     dev: false
 
+  /playwright-chromium@1.42.1:
+    resolution: {integrity: sha512-VelpmKJ+3G3QlAFfA9JIuEYyU8b8vQrlIPY3tIaGv+adn7mem56SP04e+zMudcxisfOT3suQOSTD1qs6YErdDg==}
+    engines: {node: '>=16'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      playwright-core: 1.42.1
+    dev: false
+
   /playwright-core@1.42.1:
-    resolution: {integrity: sha1-E8FQuTyUCjKAqx0/vJRbyFXJRZ4=}
+    resolution: {integrity: sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==}
     engines: {node: '>=16'}
     hasBin: true
     dev: false
 
   /playwright@1.42.1:
-    resolution: {integrity: sha1-ecgotR/jgwIRE3VQVCQmER3II58=}
+    resolution: {integrity: sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
@@ -3933,6 +4082,11 @@ packages:
 
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha1-eCDZsWEgzFXKmud5JoCufbptf+I=}
+    dev: false
+
+  /process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
     dev: false
 
   /prom-client@14.2.0:
@@ -4252,7 +4406,7 @@ packages:
     dev: false
 
   /source-map@0.6.1:
-    resolution: {integrity: sha1-dHIq8y6WFOnCh6jQu95IteLxomM=}
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
     requiresBuild: true
     dev: false
@@ -4439,6 +4593,10 @@ packages:
       url-parse: 1.5.10
     dev: false
 
+  /tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: false
+
   /try-require@1.2.1:
     resolution: {integrity: sha1-NEiaLKwMCcHMEO2RugEVlNQzO+I=}
     dev: false
@@ -4488,7 +4646,7 @@ packages:
     dev: false
 
   /tslib@2.6.2:
-    resolution: {integrity: sha1-cDrClCXns3zW/UVukkBNRtHz5K4=}
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: false
 
   /tsutils@3.21.0(typescript@5.3.3):
@@ -4499,6 +4657,11 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 5.3.3
+    dev: false
+
+  /tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
     dev: false
 
   /type-fest@0.21.3:
@@ -4527,7 +4690,7 @@ packages:
     dev: false
 
   /unix-dgram@2.0.6:
-    resolution: {integrity: sha1-bVZ7DrbXqVBOVhUytZikbjTFlos=}
+    resolution: {integrity: sha512-AURroAsb73BZ6CdAyMrTk/hYKNj3DuYYEuOaB8bYMOHGKupRNScw90Q5C71tWJc3uE7dIeXRyuwN0xLLq3vDTg==}
     engines: {node: '>=0.10.48'}
     requiresBuild: true
     dependencies:
@@ -4589,6 +4752,17 @@ packages:
     resolution: {integrity: sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=}
     dependencies:
       defaults: 1.0.4
+    dev: false
+
+  /webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: false
+
+  /whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
     dev: false
 
   /which-typed-array@1.1.14:
@@ -4672,6 +4846,14 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: false
+
+  /xml2js@0.5.0:
+    resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      sax: 1.2.1
+      xmlbuilder: 11.0.1
     dev: false
 
   /xml2js@0.6.2:

--- a/scripts/the-pied-pine-perf.yml
+++ b/scripts/the-pied-pine-perf.yml
@@ -1,16 +1,18 @@
 config:
   target: http://localhost:3000
+  timeout: 120
   engines: 
     playwright: 
       launchOptions: 
-       headless: false
+       headless: true
+      
   phases:
     # to limit to an exact number of virtual users, set both duration and rampTo to the same number
     # other options will continually spawn new users
     # https://www.artillery.io/docs/reference/test-script#load-phase-examples
-    - duration: 2 
-      rampTo: 2
-      name: Test Two Users # supposed to have 'ramp-up' 'high traffic' etc...
+    - duration: 1
+      rampTo: 1
+      name: One User # supposed to have 'ramp-up' 'high traffic' etc...
 
   processor: "../tests/test.mjs"
   plugins:
@@ -21,7 +23,7 @@ config:
     threshold: 100
   ensure:
       thresholds:
-        - browser.step.spinner_stage.median: 20000 # If actually implementing as part of a CI pipeline, then this asserts the spinner test did not go past 20 seconds.
+        - browser.step.spinner_stage.median: 100000 # If actually implementing as part of a CI pipeline, then this asserts the spinner test did not go past 20 seconds.
 scenarios:
   - engine: playwright
     testFunction: untilCanvas

--- a/tests/blobs.mjs
+++ b/tests/blobs.mjs
@@ -1,0 +1,20 @@
+import dotenv from "dotenv";
+import { BlobServiceClient } from "@azure/storage-blob";
+
+dotenv.config();
+
+// Create a new blob in the main container
+export async function addResults(blobName, content) {
+  if (!process.env.azBlobConnectionString) {
+    console.warn(
+      "No azBlobConnectionString provided. Results will not be uploaded."
+    );
+    return;
+  }
+  const blobClient = BlobServiceClient.fromConnectionString(
+    process.env.azBlobConnectionString
+  );
+  const containerClient = blobClient.getContainerClient("main");
+  const blockBlobClient = containerClient.getBlockBlobClient(blobName);
+  await blockBlobClient.upload(content, content.length);
+}


### PR DESCRIPTION
- Add request logging via the playwright  `requestfinished` event. 
- Add ability to upload reports to blob storage

Data gathered from requests looks like:
<img width="802" alt="image" src="https://github.com/ben-polinsky/pine-perf-testing/assets/78756012/ae99a64a-9984-4894-b0fc-f7eb7ca6155f">

Also the top n most expensive requests are listed:
<img width="914" alt="image" src="https://github.com/ben-polinsky/pine-perf-testing/assets/78756012/55199865-8287-47cd-b152-6315cb36b525">
Though most requests do not happen more than once in a session, this script does average the times if they do.
